### PR TITLE
feat(infra): add Terraform Lightsail deployment, Docker Hub workflow, and CI tests

### DIFF
--- a/.github/workflows/ci.yalm
+++ b/.github/workflows/ci.yalm
@@ -1,0 +1,82 @@
+name: CI - Test, Build & Push Docker
+
+on:
+  push:
+    branches: [ main ]    # adjust if your default branch is different
+    tags: [ 'v*' ]        # push Docker image with the same tag when you create git tags like v1.2.3
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/tui-li
+
+jobs:
+  test:
+    name: Rust tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install stable Rust toolchain
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # Cache target/ and cargo registry/git to speed up builds
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # Optional: ensure Cargo.lock is respected for reproducible builds
+      - name: Run tests
+        run: cargo test --locked --all-features --all-targets --verbose
+
+  docker:
+    name: Build & Push Docker image
+    runs-on: ubuntu-latest
+    needs: [ test ]
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Set up QEMU and Buildx (multi-arch capable; we’ll build amd64 for Lightsail)
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Log in to Docker Hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Generate Docker tags/labels automatically from branch/tag/sha
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            # “latest” on default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            # When pushing git tags like v1.2.3 → tag image v1.2.3
+            type=ref,event=tag
+
+      # Build & push (Linux/amd64 so it runs on Lightsail)
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,27 @@ Desktop.ini
 Cargo.lock        # (ignore if you're making a library, commit if it's a binary project)
 .cargo/
 .cargo-ok
+/target/
+/Cargo.lock
+**/*.rs.bk
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraform.lock.hcl
+
+# VSCode
+.vscode/
+
+# Others
+.DS_Store
+
 
 # Logs
 *.log

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,43 @@
+# 1) Create the Lightsail Container Service
+resource "aws_lightsail_container_service" "service" {
+  name  = var.service_name
+  power = var.power
+  scale = var.scale
+
+  tags = {
+    app         = var.service_name
+    environment = "dev"       # adjust as needed: dev | staging | prod
+    managed_by  = "terraform" # helpful for AWS console clarity
+  }
+}
+
+# 2) Deploy using a public image from Docker Hub
+resource "aws_lightsail_container_service_deployment_version" "deployment" {
+  service_name = aws_lightsail_container_service.service.name
+
+  container {
+    container_name = var.container_name
+    image          = var.container_image  # e.g. "youruser/tui-li:latest"
+    environment = {
+      HOST     = "0.0.0.0"
+      PORT     = tostring(var.container_port)
+      RUST_LOG = "info"
+    }
+    ports = {
+      "${var.container_port}" = "HTTP"
+    }
+  }
+
+  public_endpoint {
+    container_name = var.container_name
+    container_port = var.container_port
+    health_check {
+      path                = var.health_check_path
+      success_codes       = "200-399"
+      interval_seconds    = 5
+      timeout_seconds     = 2
+      healthy_threshold   = 2
+      unhealthy_threshold = 2
+    }
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,9 @@
+output "service_name" {
+  value       = aws_lightsail_container_service.service.name
+  description = "Lightsail container service name."
+}
+
+output "service_url" {
+  value       = aws_lightsail_container_service.service.url
+  description = "Default public HTTPS URL (works after a deployment with a public endpoint)."
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.50"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,39 @@
+variable "region" {
+  type    = string
+  default = "ap-southeast-2"
+}
+
+variable "service_name" {
+  type    = string
+  default = "tui-li"
+}
+
+variable "power" {
+  type    = string
+  default = "nano"   # nano|micro|small|medium|large|xlarge
+}
+
+variable "scale" {
+  type    = number
+  default = 1
+}
+
+variable "container_name" {
+  type    = string
+  default = "api"
+}
+
+variable "container_port" {
+  type    = number
+  default = 3000
+}
+
+variable "health_check_path" {
+  type    = string
+  default = "/health"
+}
+
+variable "container_image" {
+  type = string
+  description = "Public Docker image reference (Docker Hub, ECR, etc.)"
+}


### PR DESCRIPTION
- Split Terraform into providers.tf, variables.tf, main.tf, outputs.tf
- Standardize variable naming (container_image, health_check_path, etc.)
- Add Sydney (ap-southeast-2) as default region support
- Refactor Terraform resources: aws_lightsail_container_service (service), aws_lightsail_container_service_deployment_version (deployment)
- Add tagging convention (app, environment, managed_by)
- Add GitHub Actions workflow for Rust tests and Docker build/push to Docker Hub
- Docker Hub login via secrets (DOCKERHUB_USERNAME, DOCKERHUB_TOKEN)
- Build multi-stage Dockerfile for tui-li (Rust → Alpine runtime)