### PR TITLE
fix(ci): build image name inside reusable workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
     branches: [ main ]
     tags: [ 'v*' ]
 
-env:
-  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/tui-li-api
-
 jobs:
   tests:
     uses: ./.github/workflows/test.yml
@@ -15,9 +12,9 @@ jobs:
   docker:
     needs: tests
     uses: ./.github/workflows/docker.yml
-    with:
-      image_name: ${{ env.IMAGE_NAME }}
+    secrets: inherit  # lets the called workflow use DOCKERHUB_* secrets
 
   terraform:
     needs: docker
     uses: ./.github/workflows/terraform.yml
+    secrets: inherit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ inputs.image_name }}
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/tui-li-api
           tags: |
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -36,5 +36,5 @@ variable "health_check_path" {
 variable "container_image" {
   type = string
   description = "Public Docker image reference (Docker Hub, ECR, etc.)"
-  default     = "glexposito/tui-li:latest"
+  default     = "glexposito/tui-li-api:latest"
 }


### PR DESCRIPTION
- Removed `image_name` input from deploy workflow call